### PR TITLE
Close Body After Timeout [#4]

### DIFF
--- a/acexy/go.mod
+++ b/acexy/go.mod
@@ -3,3 +3,5 @@ module javinator9889/acexy
 go 1.22
 
 require github.com/google/uuid v1.6.0 // direct
+
+require github.com/dustin/go-humanize v1.0.1 // indirect

--- a/acexy/go.sum
+++ b/acexy/go.sum
@@ -1,2 +1,4 @@
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/acexy/lib/acexy/copier.go
+++ b/acexy/lib/acexy/copier.go
@@ -1,0 +1,74 @@
+package acexy
+
+import (
+	"bufio"
+	"io"
+	"log/slog"
+	"time"
+)
+
+// Copier is an implementation that copies the data from the source to the destination.
+// It has an empty timeout that is used to determine when the source is empty - this is,
+// it has no more data to read after the timeout.
+type Copier struct {
+	// The destination to copy the data to.
+	Destination io.Writer
+	// The source to copy the data from.
+	Source io.Reader
+	// The timeout to use when the source is empty.
+	EmptyTimeout time.Duration
+	// The buffer size to use when copying the data.
+	BufferSize int
+
+	/**! Private Data */
+	timer          *time.Timer
+	bufferedWriter *bufio.Writer
+}
+
+// Starts copying the data from the source to the destination.
+func (c *Copier) Copy() error {
+	c.bufferedWriter = bufio.NewWriterSize(c.Destination, c.BufferSize)
+	c.timer = time.NewTimer(c.EmptyTimeout)
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			c.timer.Reset(c.EmptyTimeout)
+			select {
+			case <-done:
+				slog.Debug("Done copying", "source", c.Source, "destination", c.Destination)
+				return
+			case <-c.timer.C:
+				// On timeout, flush the buffer, and close both the source and the destination
+				c.bufferedWriter.Flush()
+				if closer, ok := c.Source.(io.Closer); ok {
+					slog.Debug("Closing source", "source", c.Source)
+					closer.Close()
+				}
+				if closer, ok := c.Destination.(io.Closer); ok {
+					slog.Debug("Closing destination", "destination", c.Destination)
+					closer.Close()
+				}
+				return
+			}
+		}
+	}()
+
+	_, err := io.Copy(c, c.Source)
+	return err
+}
+
+// Write writes the data to the destination. It also resets the timer if there is data to write.
+func (c *Copier) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if c.timer == nil || c.bufferedWriter == nil {
+		return 0, io.ErrClosedPipe
+	}
+	// Reset the timer, since we have data to write
+	c.timer.Reset(c.EmptyTimeout)
+	// Write the data to the destination
+	return c.bufferedWriter.Write(p)
+}

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -142,3 +142,22 @@ func (pmw *PMultiWriter) Remove(w io.Writer) {
 	}
 	pmw.writers = writers
 }
+
+// Closes all the writers in the list.
+func (pmw *PMultiWriter) Close() error {
+	pmw.Lock()
+	defer pmw.Unlock()
+
+	var errors []error
+	for _, w := range pmw.writers {
+		if c, ok := w.(io.Closer); ok {
+			if err := c.Close(); err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+	if len(errors) > 0 {
+		return PMultiWriterError{Errors: errors, Writers: len(pmw.writers)}
+	}
+	return nil
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,5 @@ services:
       ACEXY_PORT: "6878"          # Port is 6878
       ACEXY_M3U8_STREAM_TIMEOUT: "60s"  # Timeout is 60 seconds when in M3U8 mode
       ACEXY_M3U8: "false"         # Disable M3U8 mode
+      ACEXY_EMPTY_TIMEOUT: "60s"  # Timeout to close the connection if no data is received
+      ACEXY_BUFFER_SIZE: 32768    # Buffer size is 32KB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       ACEXY_M3U8_STREAM_TIMEOUT: "60s"  # Timeout is 60 seconds when in M3U8 mode
       ACEXY_M3U8: "false"         # Disable M3U8 mode
       ACEXY_EMPTY_TIMEOUT: "60s"  # Timeout to close the connection if no data is received
-      ACEXY_BUFFER_SIZE: 32768    # Buffer size is 32KB
+      ACEXY_BUFFER_SIZE: 4MB      # Buffer size is 4MB


### PR DESCRIPTION
This PR adds a timeout to close both transmission ends when a timeout occurs and no data was received during that time. This change also introduces a buffer in the proxy to cache contents and stream them easily. It defaults to `4MiB`, but can be disabled at any time by setting its size to `0`.