### PR TITLE
[Acexy] Ace ID: Remove unnecessary API method

### DIFF
--- a/acexy/lib/acexy/aceid.go
+++ b/acexy/lib/acexy/aceid.go
@@ -5,7 +5,6 @@ package acexy
 import (
 	"errors"
 	"fmt"
-	"net/url"
 )
 
 type AceID struct {
@@ -25,11 +24,6 @@ func NewAceID(id, infohash string) (AceID, error) {
 		return AceID{}, errors.New("only one of `id` or `infohash` can have a value")
 	}
 	return AceID{id: id, infohash: infohash}, nil
-}
-
-// Create a new `AceID` object from URL parameters
-func AceIDFromParams(params url.Values) (AceID, error) {
-	return NewAceID(params.Get("id"), params.Get("infohash"))
 }
 
 // Get the valid AceStream ID. If the `infohash` is set, it will be returned,

--- a/acexy/proxy.go
+++ b/acexy/proxy.go
@@ -45,7 +45,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 	// Verify the client has included the ID parameter
-	aceId, err := acexy.AceIDFromParams(q)
+	aceId, err := acexy.NewAceID(q.Get("id"), q.Get("infohash"))
 	if err != nil {
 		slog.Error("ID parameter is required", "path", r.URL.Path, "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
The `aceid` module had some extra APIs not necessary for normal behavior. These have been removed.