### PR TITLE
[Dev/#18] HEALTHCHECK Support in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ COPY --link             bin/entrypoint /bin/entrypoint
 COPY --from=build-stage /acexy         /acexy
 EXPOSE 8080
 ENV EXTRA_FLAGS="--cache-dir /tmp --cache-limit 2 --cache-auto 1 --log-stderr --log-stderr-level error"
+ENV ACEXY_LISTEN_ADDR=":8080"
 # USER acestream:acestream
+
+# Install curl for healthcheck
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Healthcheck against the HTTP status endpoint
+HEALTHCHECK --interval=10s --timeout=10s --start-period=1s \
+    CMD curl -qf http://localhost${ACEXY_LISTEN_ADDR}/ace/status || exit 1
 
 ENTRYPOINT [ "/bin/entrypoint" ]


### PR DESCRIPTION
A new endpoint `/status` was added to obtain the current status of both the proxy and the running streams. The status can be accessed with `?id=<acestream-id>` or `?infohash=<acestream-infohash>` to query the current streaming status, and access underlying data.

On the other hand, the `/status` endpoint is now used by the Docker containers to verify the correct behavior of the proxy.

closes #18