### PR TITLE
Proxy: Set production-ready read/write timeouts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,9 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test -v ./... -json > TestResults-${{ matrix.go-version }}.json
+        run: go test -v ./... -json | tee TestResults-${{ matrix.go-version }}.json
+      - name: Debug output
+        run: ls -l TestResults-${{ matrix.go-version }}.json && cat TestResults-${{ matrix.go-version }}.json | head -n 20
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,10 +25,8 @@ jobs:
         run: go build -v ./...
       - name: Test
         run: go test -v ./... -json | tee TestResults-${{ matrix.go-version }}.json
-      - name: Debug output
-        run: ls -l TestResults-${{ matrix.go-version }}.json && cat TestResults-${{ matrix.go-version }}.json | head -n 20
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
           name: Go-results-${{ matrix.go-version }}
-          path: TestResults-${{ matrix.go-version }}.json
+          path: acexy/TestResults-${{ matrix.go-version }}.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Go
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/acexy/lib/acexy/acexy.go
+++ b/acexy/lib/acexy/acexy.go
@@ -66,6 +66,7 @@ type AceStream struct {
 type ongoingStream struct {
 	clients  uint
 	done     chan struct{}
+	closeDone sync.Once // guards close(done) against concurrent callers
 	player   *http.Response
 	stream   *AceStream
 	copier   *Copier
@@ -124,19 +125,33 @@ func (a *Acexy) Init() {
 // customize the stream.
 func (a *Acexy) FetchStream(aceId AceID, extraParams url.Values) (*AceStream, error) {
 	a.mutex.Lock()
-	defer a.mutex.Unlock()
 
 	// Check if the stream is already enqueued
 	if stream, ok := a.streams[aceId]; ok {
 		slog.Info("Reusing existing", "stream", aceId, "clients", stream.clients)
+		a.mutex.Unlock()
 		return stream.stream, nil
 	}
 
-	// Enqueue the middleware
+	// Release the mutex BEFORE the HTTP call to the AceStream backend.
+	// GetStream can take up to NoResponseTimeout (10s) and would block
+	// all other operations if the mutex were held.
+	a.mutex.Unlock()
+
 	middleware, err := GetStream(a, aceId, extraParams)
 	if err != nil {
 		slog.Error("Error getting stream middleware", "error", err)
 		return nil, err
+	}
+
+	// Re-acquire the mutex to update state
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	// Another goroutine may have created this stream while the mutex was released
+	if existing, ok := a.streams[aceId]; ok {
+		slog.Info("Reusing existing (created during fetch)", "stream", aceId, "clients", existing.clients)
+		return existing.stream, nil
 	}
 
 	// We got the stream information, build the structure around it and register the stream
@@ -182,11 +197,11 @@ func (a *Acexy) FetchStream(aceId AceID, extraParams url.Values) (*AceStream, er
 
 func (a *Acexy) StartStream(stream *AceStream, out io.Writer) error {
 	a.mutex.Lock()
-	defer a.mutex.Unlock()
 
 	// Get the ongoing stream
 	ongoingStream, ok := a.streams[stream.ID]
 	if !ok {
+		a.mutex.Unlock()
 		slog.Debug("Stream not found", "stream", stream.ID)
 		return fmt.Errorf(`stream "%s" not found`, stream.ID)
 	}
@@ -199,10 +214,34 @@ func (a *Acexy) StartStream(stream *AceStream, out io.Writer) error {
 
 	// Check if the stream is already being played
 	if ongoingStream.player != nil {
+		a.mutex.Unlock()
 		return nil
 	}
 
-	resp, err := a.middleware.Get(stream.PlaybackURL)
+	// Release the mutex BEFORE the HTTP call to the AceStream backend.
+	// This call can take up to NoResponseTimeout (10s) and would block
+	// all other operations (FetchStream, StopStream, GetStatus) if the
+	// mutex were held.
+	playbackURL := stream.PlaybackURL
+	a.mutex.Unlock()
+
+	resp, err := a.middleware.Get(playbackURL)
+
+	// Re-acquire the mutex to update state
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	// Re-check the stream still exists (could have been released while
+	// the mutex was not held)
+	ongoingStream, ok = a.streams[stream.ID]
+	if !ok {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		slog.Debug("Stream released during playback fetch", "stream", stream.ID)
+		return fmt.Errorf(`stream "%s" was released`, stream.ID)
+	}
+
 	if err != nil {
 		slog.Error("Failed to forward stream", "error", err)
 		ongoingStream.clients--
@@ -212,6 +251,12 @@ func (a *Acexy) StartStream(stream *AceStream, out io.Writer) error {
 			}
 		}
 		return err
+	}
+
+	// Another goroutine may have started playback while the mutex was released
+	if ongoingStream.player != nil {
+		resp.Body.Close()
+		return nil
 	}
 
 	// Forward the response to the writers
@@ -232,13 +277,10 @@ func (a *Acexy) StartStream(stream *AceStream, out io.Writer) error {
 			}
 		}
 		slog.Debug("Copy done", "stream", stream.ID)
-		select {
-		case <-ongoingStream.done:
-			slog.Debug("Stream already closed", "stream", stream.ID)
-		default:
+		ongoingStream.closeDone.Do(func() {
 			close(ongoingStream.done)
 			slog.Debug("Stream closed", "stream", stream.ID)
-		}
+		})
 	}()
 
 	ongoingStream.player = resp
@@ -272,14 +314,11 @@ func (a *Acexy) releaseStream(stream *AceStream) error {
 		ongoingStream.player.Body.Close()
 	}
 
-	// Close the `done' channel
-	select {
-	case <-ongoingStream.done:
-		slog.Debug("Stream already closed", "stream", stream.ID)
-	default:
+	// Close the `done' channel (safe for concurrent callers via sync.Once)
+	ongoingStream.closeDone.Do(func() {
 		close(ongoingStream.done)
 		slog.Debug("Stream done", "stream", stream.ID)
-	}
+	})
 	return nil
 }
 

--- a/acexy/lib/acexy/acexy.go
+++ b/acexy/lib/acexy/acexy.go
@@ -64,12 +64,13 @@ type AceStream struct {
 }
 
 type ongoingStream struct {
-	clients uint
-	done    chan struct{}
-	player  *http.Response
-	stream  *AceStream
-	copier  *Copier
-	writers *pmw.PMultiWriter
+	clients  uint
+	done     chan struct{}
+	player   *http.Response
+	stream   *AceStream
+	copier   *Copier
+	writers  *pmw.PMultiWriter
+	evicted  map[io.Writer]struct{} // writers evicted by PMultiWriter timeout
 }
 
 // Structure referencing the AceStream Proxy - this is, ourselves
@@ -147,14 +148,35 @@ func (a *Acexy) FetchStream(aceId AceID, extraParams url.Values) (*AceStream, er
 		ID:          aceId,
 	}
 
-	a.streams[aceId] = &ongoingStream{
+	writers := pmw.New(context.Background(), 5*time.Second)
+	os := &ongoingStream{
 		clients: 0,
 		done:    make(chan struct{}),
 		player:  nil,
 		stream:  stream,
-		writers: pmw.New(context.Background(), 5*time.Second),
+		writers: writers,
+		evicted: make(map[io.Writer]struct{}),
 	}
-	slog.Info("Started new stream", "id", aceId, "clients", a.streams[aceId].clients)
+	a.streams[aceId] = os
+
+	// When PMultiWriter evicts a slow consumer, record it and decrement the
+	// client count. StopStream checks this set to avoid double-decrementing.
+	writers.SetOnEvict(func(w io.Writer) {
+		a.mutex.Lock()
+		defer a.mutex.Unlock()
+		os.evicted[w] = struct{}{}
+		if os.clients > 0 {
+			os.clients--
+			slog.Info("Writer evicted by timeout", "stream", aceId, "clients", os.clients)
+		}
+		if os.clients == 0 {
+			if err := a.releaseStream(stream); err != nil {
+				slog.Warn("Error releasing stream after eviction", "error", err)
+			}
+		}
+	})
+
+	slog.Info("Started new stream", "id", aceId, "clients", os.clients)
 	return stream, nil
 }
 
@@ -277,6 +299,15 @@ func (a *Acexy) StopStream(stream *AceStream, out io.Writer) error {
 
 	// Remove the writer from the list of writers
 	ongoingStream.writers.Remove(out)
+
+	// If this writer was already evicted by PMultiWriter timeout, the client
+	// count was already decremented in the OnEvict callback. Skip the
+	// decrement to avoid double-counting.
+	if _, wasEvicted := ongoingStream.evicted[out]; wasEvicted {
+		delete(ongoingStream.evicted, out)
+		slog.Debug("Writer was already evicted, skipping decrement", "stream", stream.ID)
+		return nil
+	}
 
 	// Unregister the client
 	if ongoingStream.clients > 0 {

--- a/acexy/lib/acexy/acexy.go
+++ b/acexy/lib/acexy/acexy.go
@@ -5,6 +5,7 @@
 package acexy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -151,7 +152,7 @@ func (a *Acexy) FetchStream(aceId AceID, extraParams url.Values) (*AceStream, er
 		done:    make(chan struct{}),
 		player:  nil,
 		stream:  stream,
-		writers: pmw.New(),
+		writers: pmw.New(context.Background(), 5*time.Second),
 	}
 	slog.Info("Started new stream", "id", aceId, "clients", a.streams[aceId].clients)
 	return stream, nil

--- a/acexy/lib/acexy/acexy.go
+++ b/acexy/lib/acexy/acexy.go
@@ -232,7 +232,8 @@ func (a *Acexy) StartStream(stream *AceStream, out io.Writer) error {
 	defer a.mutex.Unlock()
 
 	// Re-check the stream still exists (could have been released while
-	// the mutex was not held)
+	// the mutex was not held). If the stream was released, our writer and
+	// client count were already cleaned up by releaseStream/StopStream.
 	ongoingStream, ok = a.streams[stream.ID]
 	if !ok {
 		if resp != nil {
@@ -244,6 +245,11 @@ func (a *Acexy) StartStream(stream *AceStream, out io.Writer) error {
 
 	if err != nil {
 		slog.Error("Failed to forward stream", "error", err)
+		// Remove the writer we added before the HTTP call — if we don't,
+		// the copier (started by another client) will try to write to
+		// this client's now-invalid ResponseWriter, causing a nil pointer
+		// dereference panic.
+		ongoingStream.writers.Remove(out)
 		ongoingStream.clients--
 		if ongoingStream.clients == 0 {
 			if releaseErr := a.releaseStream(stream); releaseErr != nil {

--- a/acexy/lib/acexy/acexy.go
+++ b/acexy/lib/acexy/acexy.go
@@ -342,7 +342,9 @@ func GetStream(a *Acexy, aceId AceID, extraParams url.Values) (*AceStreamMiddlew
 	req.URL.RawQuery = extraParams.Encode()
 
 	slog.Debug("Request URL", "url", req.URL.String())
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: a.NoResponseTimeout,
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		slog.Debug("Error getting stream", "error", err)
@@ -385,7 +387,12 @@ func CloseStream(stream *AceStream) error {
 	q.Add("method", "stop")
 	req.URL.RawQuery = q.Encode()
 
-	client := &http.Client{}
+	client := &http.Client{
+		/* the backend should respond in way less time than this one, but it may hang (AceStream)
+		 * is not very well coded), so we set a timeout to avoid hanging forever
+		 */
+		Timeout: 3 * time.Second,
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		return err

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -54,6 +54,7 @@ type PMultiWriter struct {
 	sync.RWMutex
 	writers      []io.Writer
 	closed       chan struct{}
+	closeOnce    sync.Once
 	ctx          context.Context
 	writeTimeout time.Duration
 	onEvict      func(io.Writer)
@@ -209,31 +210,28 @@ func (pmw *PMultiWriter) Remove(w io.Writer) {
 	pmw.writers = writers
 }
 
-// Closes all the writers in the list. Safe to call multiple times.
+// Closes all the writers in the list. Safe to call multiple times from
+// concurrent goroutines.
 func (pmw *PMultiWriter) Close() error {
-	pmw.RLock()
-	defer pmw.RUnlock()
+	var closeErrors []error
 
-	// Guard against double-close panic
-	select {
-	case <-pmw.closed:
-		return nil
-	default:
+	pmw.closeOnce.Do(func() {
+		pmw.RLock()
+		defer pmw.RUnlock()
+
 		close(pmw.closed)
-	}
-
-	var errors []error
-	for _, w := range pmw.writers {
-		if c, ok := w.(io.Closer); ok {
-			if err := c.Close(); err != nil {
-				errors = append(errors, err)
+		for _, w := range pmw.writers {
+			if c, ok := w.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					closeErrors = append(closeErrors, err)
+				}
+				slog.Debug("closed", "w", w)
 			}
-			slog.Debug("closed", "w", w)
 		}
-		/* there could be non-closeable writers. Rely on the channel to exit the goroutine */
-	}
-	if len(errors) > 0 {
-		return PMultiWriterError{Errors: errors, Writers: len(pmw.writers)}
+	})
+
+	if len(closeErrors) > 0 {
+		return PMultiWriterError{Errors: closeErrors, Writers: len(pmw.writers)}
 	}
 	return nil
 }

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -80,9 +80,10 @@ func (e PMultiWriterError) Error() string {
 // similar to the Unix tee(1) command. Writers can be added and removed
 // dynamically after creation.
 //
-// Each write is written to each listed writer, one at a time. If a listed
-// writer returns an error, that overall write operation stops and returns the
-// error; it does not continue down the list.
+// Each write is dispatched to all listed writers concurrently, typically using
+// separate goroutines. If one or more writers return an error, the write still
+// proceeds for all writers, and any errors are collected and returned after all
+// writes complete.
 func New(ctx context.Context, writeTimeout time.Duration, writers ...io.Writer) *PMultiWriter {
 	pmw := &PMultiWriter{
 		writers:      writers,

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -56,6 +56,7 @@ type PMultiWriter struct {
 	closed       chan struct{}
 	ctx          context.Context
 	writeTimeout time.Duration
+	onEvict      func(io.Writer)
 }
 
 // PMultiWriterError is an error that occurs when writing to multiple writers.
@@ -92,8 +93,29 @@ func New(ctx context.Context, writeTimeout time.Duration, writers ...io.Writer) 
 	return pmw
 }
 
+// SetOnEvict sets a callback that is called when a writer is evicted due to a write timeout.
+// The callback receives the evicted writer and is called asynchronously.
+func (pmw *PMultiWriter) SetOnEvict(fn func(io.Writer)) {
+	pmw.Lock()
+	defer pmw.Unlock()
+	pmw.onEvict = fn
+}
+
+// evict removes a writer from the list and fires the OnEvict callback if set.
+func (pmw *PMultiWriter) evict(w io.Writer) {
+	pmw.Remove(w)
+	pmw.RLock()
+	fn := pmw.onEvict
+	pmw.RUnlock()
+	if fn != nil {
+		fn(w)
+	}
+}
+
 // Write writes some bytes to all the writers.
-// If a writer takes longer than the configured timeout, it is removed from the list.
+// If a writer takes longer than the configured timeout, it is evicted from the list.
+// A write is considered successful if at least one writer succeeds. An error is only
+// returned when ALL writers fail, preserving the stream for healthy clients.
 func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 	pmw.RLock()
 	// Copy the writers so we can release the lock
@@ -123,10 +145,9 @@ func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 			case err := <-done:
 				results <- writeResult{w: w, err: err}
 			case <-time.After(pmw.writeTimeout):
-				slog.Warn("writer timed out, removing", "writer", w)
+				slog.Warn("writer timed out, evicting", "writer", w)
 				results <- writeResult{w: w, err: context.DeadlineExceeded}
-				// Asynchronously remove the slow writer
-				go pmw.Remove(w)
+				go pmw.evict(w)
 			case <-pmw.closed:
 				results <- writeResult{w: w, err: io.ErrClosedPipe}
 			case <-pmw.ctx.Done():
@@ -135,8 +156,9 @@ func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 		}(w)
 	}
 
-	// Wait for all writes to finish or timeout. If an error occurs, return it.
-	errors := make([]error, 0)
+	// Wait for all writes to finish or timeout.
+	successCount := 0
+	var writeErrors []error
 	for range writers {
 		select {
 		case <-pmw.closed:
@@ -144,13 +166,18 @@ func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 			return 0, io.ErrClosedPipe
 		case res := <-results:
 			if res.err != nil {
-				errors = append(errors, res.err)
+				slog.Debug("writer failed", "writer", res.w, "error", res.err)
+				writeErrors = append(writeErrors, res.err)
+			} else {
+				successCount++
 			}
 		}
 	}
 
-	if len(errors) > 0 {
-		return 0, PMultiWriterError{Errors: errors, Writers: len(writers)}
+	// Only return an error when ALL writers failed. If at least one succeeded,
+	// the stream is healthy and should continue.
+	if successCount == 0 && len(writeErrors) > 0 {
+		return 0, PMultiWriterError{Errors: writeErrors, Writers: len(writers)}
 	}
 
 	return len(p), nil

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -38,6 +38,8 @@ package pmw
 import (
 	"fmt"
 	"io"
+	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -49,6 +51,7 @@ import (
 type PMultiWriter struct {
 	sync.RWMutex
 	writers []io.Writer
+	closed  chan struct{}
 }
 
 // PMultiWriterError is an error that occurs when writing to multiple writers.
@@ -76,17 +79,20 @@ func (e PMultiWriterError) Error() string {
 // writer returns an error, that overall write operation stops and returns the
 // error; it does not continue down the list.
 func New(writers ...io.Writer) *PMultiWriter {
-	pmw := &PMultiWriter{writers: writers}
+	pmw := &PMultiWriter{writers: writers, closed: make(chan struct{})}
 	return pmw
 }
 
 // Write writes some bytes to all the writers.
 func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 	pmw.RLock()
-	defer pmw.RUnlock()
+	// Copy the writers so we can release the lock
+	writers := make([]io.Writer, len(pmw.writers))
+	copy(writers, pmw.writers)
+	pmw.RUnlock()
 
-	errs := make(chan error, len(pmw.writers))
-	for _, w := range pmw.writers {
+	errs := make(chan error, len(writers))
+	for _, w := range writers {
 		go func(w io.Writer) {
 			n, err := w.Write(p)
 			// Forward the error and early return
@@ -103,13 +109,19 @@ func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 
 	// Wait for all writes to finish. If an error occurs, return it.
 	errors := make([]error, 0)
-	for range pmw.writers {
-		if err := <-errs; err != nil {
-			errors = append(errors, err)
+	for range writers {
+		select {
+		case <-pmw.closed:
+			slog.Debug("closed pmw", "pmw", pmw)
+			return 0, io.ErrClosedPipe
+		case err := <-errs:
+			if err != nil {
+				errors = append(errors, err)
+			}
 		}
 	}
 	if len(errors) > 0 {
-		return len(p), PMultiWriterError{Errors: errors, Writers: len(pmw.writers)}
+		return 0, PMultiWriterError{Errors: errors, Writers: len(writers)}
 	}
 
 	return len(p), nil
@@ -121,12 +133,9 @@ func (pmw *PMultiWriter) Add(w io.Writer) {
 	defer pmw.Unlock()
 
 	// Check if the writer is already in the list
-	for _, ew := range pmw.writers {
-		if ew == w {
-			return
-		}
+	if !slices.Contains(pmw.writers, w) {
+		pmw.writers = append(pmw.writers, w)
 	}
-	pmw.writers = append(pmw.writers, w)
 }
 
 // Remove will remove a previously added writer from the list of writers.
@@ -145,16 +154,20 @@ func (pmw *PMultiWriter) Remove(w io.Writer) {
 
 // Closes all the writers in the list.
 func (pmw *PMultiWriter) Close() error {
-	pmw.Lock()
-	defer pmw.Unlock()
+	pmw.RLock()
+	defer pmw.RUnlock()
 
 	var errors []error
+
+	close(pmw.closed)
 	for _, w := range pmw.writers {
 		if c, ok := w.(io.Closer); ok {
 			if err := c.Close(); err != nil {
 				errors = append(errors, err)
 			}
+			slog.Debug("closed", "w", w)
 		}
+		/* there could be non-closeable writers. Rely on the channel to exit the goroutine */
 	}
 	if len(errors) > 0 {
 		return PMultiWriterError{Errors: errors, Writers: len(pmw.writers)}

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -209,14 +209,20 @@ func (pmw *PMultiWriter) Remove(w io.Writer) {
 	pmw.writers = writers
 }
 
-// Closes all the writers in the list.
+// Closes all the writers in the list. Safe to call multiple times.
 func (pmw *PMultiWriter) Close() error {
 	pmw.RLock()
 	defer pmw.RUnlock()
 
-	var errors []error
+	// Guard against double-close panic
+	select {
+	case <-pmw.closed:
+		return nil
+	default:
+		close(pmw.closed)
+	}
 
-	close(pmw.closed)
+	var errors []error
 	for _, w := range pmw.writers {
 		if c, ok := w.(io.Closer); ok {
 			if err := c.Close(); err != nil {

--- a/acexy/lib/pmw/pmw.go
+++ b/acexy/lib/pmw/pmw.go
@@ -36,12 +36,14 @@
 package pmw
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"slices"
 	"strings"
 	"sync"
+	"time"
 )
 
 // PMultiWriter is an implementation of an "io.Writer" that duplicates its writes
@@ -50,8 +52,10 @@ import (
 // goroutine, so the writes are done in parallel.
 type PMultiWriter struct {
 	sync.RWMutex
-	writers []io.Writer
-	closed  chan struct{}
+	writers      []io.Writer
+	closed       chan struct{}
+	ctx          context.Context
+	writeTimeout time.Duration
 }
 
 // PMultiWriterError is an error that occurs when writing to multiple writers.
@@ -78,12 +82,18 @@ func (e PMultiWriterError) Error() string {
 // Each write is written to each listed writer, one at a time. If a listed
 // writer returns an error, that overall write operation stops and returns the
 // error; it does not continue down the list.
-func New(writers ...io.Writer) *PMultiWriter {
-	pmw := &PMultiWriter{writers: writers, closed: make(chan struct{})}
+func New(ctx context.Context, writeTimeout time.Duration, writers ...io.Writer) *PMultiWriter {
+	pmw := &PMultiWriter{
+		writers:      writers,
+		closed:       make(chan struct{}),
+		ctx:          ctx,
+		writeTimeout: writeTimeout,
+	}
 	return pmw
 }
 
 // Write writes some bytes to all the writers.
+// If a writer takes longer than the configured timeout, it is removed from the list.
 func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 	pmw.RLock()
 	// Copy the writers so we can release the lock
@@ -91,35 +101,54 @@ func (pmw *PMultiWriter) Write(p []byte) (n int, err error) {
 	copy(writers, pmw.writers)
 	pmw.RUnlock()
 
-	errs := make(chan error, len(writers))
+	if len(writers) == 0 {
+		return len(p), nil
+	}
+
+	type writeResult struct {
+		w   io.Writer
+		err error
+	}
+
+	results := make(chan writeResult, len(writers))
 	for _, w := range writers {
 		go func(w io.Writer) {
-			n, err := w.Write(p)
-			// Forward the error and early return
-			if err != nil || n < len(p) {
-				if err == nil && n < len(p) {
-					err = io.ErrShortWrite
-				}
-				errs <- err
-			} else {
-				errs <- nil
+			done := make(chan error, 1)
+			go func() {
+				_, err := w.Write(p)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				results <- writeResult{w: w, err: err}
+			case <-time.After(pmw.writeTimeout):
+				slog.Warn("writer timed out, removing", "writer", w)
+				results <- writeResult{w: w, err: context.DeadlineExceeded}
+				// Asynchronously remove the slow writer
+				go pmw.Remove(w)
+			case <-pmw.closed:
+				results <- writeResult{w: w, err: io.ErrClosedPipe}
+			case <-pmw.ctx.Done():
+				results <- writeResult{w: w, err: pmw.ctx.Err()}
 			}
 		}(w)
 	}
 
-	// Wait for all writes to finish. If an error occurs, return it.
+	// Wait for all writes to finish or timeout. If an error occurs, return it.
 	errors := make([]error, 0)
 	for range writers {
 		select {
 		case <-pmw.closed:
 			slog.Debug("closed pmw", "pmw", pmw)
 			return 0, io.ErrClosedPipe
-		case err := <-errs:
-			if err != nil {
-				errors = append(errors, err)
+		case res := <-results:
+			if res.err != nil {
+				errors = append(errors, res.err)
 			}
 		}
 	}
+
 	if len(errors) > 0 {
 		return 0, PMultiWriterError{Errors: errors, Writers: len(writers)}
 	}

--- a/acexy/lib/pmw/pmw_test.go
+++ b/acexy/lib/pmw/pmw_test.go
@@ -1,0 +1,89 @@
+package pmw
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type blockWriter struct {
+	mu      sync.Mutex
+	blocked bool
+}
+
+func (b *blockWriter) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	b.blocked = true
+	b.mu.Unlock()
+	
+	// Block forever
+	select {}
+}
+
+type fastWriter struct {
+	mu    sync.Mutex
+	wrote int
+}
+
+func (f *fastWriter) Write(p []byte) (n int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.wrote += len(p)
+	return len(p), nil
+}
+
+func TestSlowWriterEviction(t *testing.T) {
+	fast := &fastWriter{}
+	slow := &blockWriter{}
+	
+	timeout := 100 * time.Millisecond
+	pmw := New(context.Background(), timeout, fast, slow)
+	
+	data := []byte("test data")
+	_, err := pmw.Write(data)
+	
+	if err == nil {
+		t.Error("Expected error from Write due to slow consumer, got nil")
+	}
+	
+	// The fast writer should have received data
+	fast.mu.Lock()
+	if fast.wrote != len(data) {
+		t.Errorf("Fast writer should have received %d bytes, got %d", len(data), fast.wrote)
+	}
+	fast.mu.Unlock()
+	
+	// Give some time for the async removal to happen
+	time.Sleep(200 * time.Millisecond)
+	
+	pmw.RLock()
+	defer pmw.RUnlock()
+	if len(pmw.writers) != 1 {
+		t.Errorf("Expected 1 writer after eviction, got %d", len(pmw.writers))
+	}
+	
+	if pmw.writers[0] != fast {
+		t.Error("Remaining writer should be the fast one")
+	}
+}
+
+func TestNormalWrite(t *testing.T) {
+	w1 := &fastWriter{}
+	w2 := &fastWriter{}
+	
+	pmw := New(context.Background(), 1*time.Second, w1, w2)
+	
+	data := []byte("hello")
+	n, err := pmw.Write(data)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Expected n=%d, got %d", len(data), n)
+	}
+	
+	if w1.wrote != len(data) || w2.wrote != len(data) {
+		t.Error("Both writers should have received data")
+	}
+}

--- a/acexy/lib/pmw/pmw_test.go
+++ b/acexy/lib/pmw/pmw_test.go
@@ -2,7 +2,9 @@ package pmw
 
 import (
 	"context"
+	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -16,7 +18,7 @@ func (b *blockWriter) Write(p []byte) (n int, err error) {
 	b.mu.Lock()
 	b.blocked = true
 	b.mu.Unlock()
-	
+
 	// Block forever
 	select {}
 }
@@ -36,44 +38,98 @@ func (f *fastWriter) Write(p []byte) (n int, err error) {
 func TestSlowWriterEviction(t *testing.T) {
 	fast := &fastWriter{}
 	slow := &blockWriter{}
-	
+
 	timeout := 100 * time.Millisecond
 	pmw := New(context.Background(), timeout, fast, slow)
-	
+
 	data := []byte("test data")
-	_, err := pmw.Write(data)
-	
-	if err == nil {
-		t.Error("Expected error from Write due to slow consumer, got nil")
+	n, err := pmw.Write(data)
+
+	// Write must succeed because the fast writer succeeded
+	if err != nil {
+		t.Errorf("Expected no error from Write (fast writer succeeded), got: %v", err)
 	}
-	
+	if n != len(data) {
+		t.Errorf("Expected n=%d, got %d", len(data), n)
+	}
+
 	// The fast writer should have received data
 	fast.mu.Lock()
 	if fast.wrote != len(data) {
 		t.Errorf("Fast writer should have received %d bytes, got %d", len(data), fast.wrote)
 	}
 	fast.mu.Unlock()
-	
-	// Give some time for the async removal to happen
+
+	// Give some time for the async eviction to happen
 	time.Sleep(200 * time.Millisecond)
-	
+
 	pmw.RLock()
 	defer pmw.RUnlock()
 	if len(pmw.writers) != 1 {
 		t.Errorf("Expected 1 writer after eviction, got %d", len(pmw.writers))
 	}
-	
+
 	if pmw.writers[0] != fast {
 		t.Error("Remaining writer should be the fast one")
+	}
+}
+
+func TestOnEvictCallback(t *testing.T) {
+	fast := &fastWriter{}
+	slow := &blockWriter{}
+
+	timeout := 100 * time.Millisecond
+	pmw := New(context.Background(), timeout, fast, slow)
+
+	var evicted atomic.Value
+	pmw.SetOnEvict(func(w io.Writer) {
+		evicted.Store(w)
+	})
+
+	data := []byte("test data")
+	_, _ = pmw.Write(data)
+
+	// Give time for eviction callback to fire
+	time.Sleep(200 * time.Millisecond)
+
+	ev := evicted.Load()
+	if ev == nil {
+		t.Fatal("OnEvict callback was not called")
+	}
+	if ev != slow {
+		t.Error("OnEvict callback should have received the slow writer")
+	}
+}
+
+func TestAllWritersFail(t *testing.T) {
+	slow1 := &blockWriter{}
+	slow2 := &blockWriter{}
+
+	timeout := 100 * time.Millisecond
+	pmw := New(context.Background(), timeout, slow1, slow2)
+
+	data := []byte("test data")
+	n, err := pmw.Write(data)
+
+	if err == nil {
+		t.Error("Expected error when all writers fail, got nil")
+	}
+	if n != 0 {
+		t.Errorf("Expected n=0 when all writers fail, got %d", n)
+	}
+
+	_, ok := err.(PMultiWriterError)
+	if !ok {
+		t.Errorf("Expected PMultiWriterError, got %T", err)
 	}
 }
 
 func TestNormalWrite(t *testing.T) {
 	w1 := &fastWriter{}
 	w2 := &fastWriter{}
-	
+
 	pmw := New(context.Background(), 1*time.Second, w1, w2)
-	
+
 	data := []byte("hello")
 	n, err := pmw.Write(data)
 	if err != nil {
@@ -82,7 +138,7 @@ func TestNormalWrite(t *testing.T) {
 	if n != len(data) {
 		t.Errorf("Expected n=%d, got %d", len(data), n)
 	}
-	
+
 	if w1.wrote != len(data) || w2.wrote != len(data) {
 		t.Error("Both writers should have received data")
 	}

--- a/acexy/lib/pmw/pmw_test.go
+++ b/acexy/lib/pmw/pmw_test.go
@@ -124,6 +124,20 @@ func TestAllWritersFail(t *testing.T) {
 	}
 }
 
+func TestCloseIdempotent(t *testing.T) {
+	w := &fastWriter{}
+	pmw := New(context.Background(), 1*time.Second, w)
+
+	if err := pmw.Close(); err != nil {
+		t.Fatalf("First Close() returned error: %v", err)
+	}
+
+	// Second Close() must not panic
+	if err := pmw.Close(); err != nil {
+		t.Fatalf("Second Close() returned error: %v", err)
+	}
+}
+
 func TestNormalWrite(t *testing.T) {
 	w1 := &fastWriter{}
 	w2 := &fastWriter{}

--- a/acexy/proxy.go
+++ b/acexy/proxy.go
@@ -91,19 +91,28 @@ func (p *Proxy) HandleStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// And start playing the stream. The `StartStream` will dump the contents of the new or
+	// Set response headers BEFORE starting the stream. Once StartStream is called,
+	// the copier can immediately begin writing to the ResponseWriter from another
+	// goroutine. Headers and WriteHeader must be set first to avoid a data race.
+	switch p.Acexy.Endpoint {
+	case acexy.M3U8_ENDPOINT:
+		w.Header().Set("Content-Type", "application/x-mpegURL")
+	case acexy.MPEG_TS_ENDPOINT:
+		w.Header().Set("Content-Type", "video/MP2T")
+		w.Header().Set("Transfer-Encoding", "chunked")
+	}
+	w.WriteHeader(http.StatusOK)
+
+	// Start playing the stream. The `StartStream` will dump the contents of the new or
 	// existing stream to the client. It takes an interface of `io.Writer` to write the stream
 	// contents to. The `http.ResponseWriter` implements the `io.Writer` interface, so we can
 	// pass it directly.
 	slog.Debug("Starting stream", "path", r.URL.Path, "id", aceId)
 	if err := p.Acexy.StartStream(stream, w); err != nil {
 		slog.Error("Failed to start stream", "stream", aceId, "error", err)
-		http.Error(w, "Failed to start stream: "+err.Error(), http.StatusInternalServerError)
+		// Headers already sent, so we can't use http.Error. Just log and return.
 		return
 	}
-
-	// Update the client headers
-	w.WriteHeader(http.StatusOK)
 
 	// Defer the stream finish. This will be called when the request is done. When in M3U8 mode,
 	// the client connects directly to a subset of endpoints, so we are blind to what the client
@@ -115,15 +124,12 @@ func (p *Proxy) HandleStream(w http.ResponseWriter, r *http.Request) {
 	// This is a blocking operation, so we can finish the stream when the client disconnects.
 	switch p.Acexy.Endpoint {
 	case acexy.M3U8_ENDPOINT:
-		w.Header().Set("Content-Type", "application/x-mpegURL")
 		timedOut := acexy.SetTimeout(streamTimeout)
 		defer func() {
 			<-timedOut
 			p.Acexy.StopStream(stream, w)
 		}()
 	case acexy.MPEG_TS_ENDPOINT:
-		w.Header().Set("Content-Type", "video/MP2T")
-		w.Header().Set("Transfer-Encoding", "chunked")
 		defer p.Acexy.StopStream(stream, w)
 	}
 

--- a/acexy/proxy.go
+++ b/acexy/proxy.go
@@ -93,7 +93,10 @@ func (p *Proxy) HandleStream(w http.ResponseWriter, r *http.Request) {
 
 	// Set response headers BEFORE starting the stream. Once StartStream is called,
 	// the copier can immediately begin writing to the ResponseWriter from another
-	// goroutine. Headers and WriteHeader must be set first to avoid a data race.
+	// goroutine. Header map writes are safe before the first Write/WriteHeader call.
+	// We intentionally do NOT call WriteHeader here — Go's HTTP server calls it
+	// implicitly on the first Write, and keeping it implicit means we can still
+	// return an HTTP error if StartStream fails.
 	switch p.Acexy.Endpoint {
 	case acexy.M3U8_ENDPOINT:
 		w.Header().Set("Content-Type", "application/x-mpegURL")
@@ -101,7 +104,6 @@ func (p *Proxy) HandleStream(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "video/MP2T")
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}
-	w.WriteHeader(http.StatusOK)
 
 	// Start playing the stream. The `StartStream` will dump the contents of the new or
 	// existing stream to the client. It takes an interface of `io.Writer` to write the stream
@@ -110,7 +112,7 @@ func (p *Proxy) HandleStream(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("Starting stream", "path", r.URL.Path, "id", aceId)
 	if err := p.Acexy.StartStream(stream, w); err != nil {
 		slog.Error("Failed to start stream", "stream", aceId, "error", err)
-		// Headers already sent, so we can't use http.Error. Just log and return.
+		http.Error(w, "Failed to start stream: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/acexy/proxy.go
+++ b/acexy/proxy.go
@@ -316,7 +316,7 @@ func parseArgs() {
 	flag.DurationVar(
 		&noResponseTimeout,
 		"no-response-timeout",
-		LookupEnvOrDuration("ACEXY_NO_RESPONSE_TIMEOUT", 1*time.Second),
+		LookupEnvOrDuration("ACEXY_NO_RESPONSE_TIMEOUT", 10*time.Second),
 		"timeout in human-readable format to wait for a response from the AceStream middleware. "+
 			"Can be set with ACEXY_NO_RESPONSE_TIMEOUT environment variable. "+
 			"Depending on the network conditions, you may want to adjust this value",

--- a/acexy/repro_test.go
+++ b/acexy/repro_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"javinator9889/acexy/lib/acexy"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Mock AceStream Backend
+func startMockBackend() *httptest.Server {
+	mux := http.NewServeMux()
+	
+	// /ace/getstream endpoint
+	mux.HandleFunc("/ace/getstream", func(w http.ResponseWriter, r *http.Request) {
+		// Return JSON response with playback URL
+		// We'll point playback URL to another handler on this server
+		host := r.Host
+		jsonResp := fmt.Sprintf(`{
+			"response": {
+				"playback_url": "http://%s/stream",
+				"stat_url": "http://%s/stat",
+				"command_url": "http://%s/command",
+				"infohash": "hash",
+				"playback_session_id": "session",
+				"is_live": 1,
+				"is_encrypted": 0,
+				"client_session_id": 123
+			},
+			"error": null
+		}`, host, host, host)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(jsonResp))
+	})
+
+	// /stream endpoint (Infinite stream)
+	mux.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
+		// Write data continuously
+		chunk := make([]byte, 1024) // 1KB chunk
+		for i := 0; i < len(chunk); i++ {
+			chunk[i] = 'A'
+		}
+		
+		for {
+			_, err := w.Write(chunk)
+			if err != nil {
+				return
+			}
+			// Don't sleep, we want to fill buffers
+			// But maybe a tiny sleep to yield
+			// time.Sleep(1 * time.Millisecond)
+		}
+	})
+
+	// /command endpoint
+	mux.HandleFunc("/command", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"response": "ok", "error": null}`))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestDeadlockReproduction(t *testing.T) {
+	// Setup Logging
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	handler := slog.NewTextHandler(os.Stdout, opts)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	// Start Mock Backend
+	backend := startMockBackend()
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendPort := backendURL.Port()
+	backendHost := backendURL.Hostname()
+
+	// Configure Acexy
+	// Small buffer size to fill it quickly
+	bufferSize := 1024 
+
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendHost,
+		Port:              mustParseInt(backendPort),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      5 * time.Second,
+		BufferSize:        bufferSize,
+		NoResponseTimeout: 2 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Helper to make a request
+	makeRequest := func(client *http.Client, id string) (*http.Response, error) {
+		req, _ := http.NewRequest("GET", proxyServer.URL+"/ace/getstream?id="+id, nil)
+		return client.Do(req)
+	}
+
+	streamID := "teststream"
+
+	// 1. Client A connects and blocks (reads nothing)
+	// We need a custom client that doesn't read the body
+	fmt.Println("Step 1: Client A connecting...")
+	clientA := &http.Client{Transport: &http.Transport{}}
+	respA, err := makeRequest(clientA, streamID)
+	if err != nil {
+		t.Fatalf("Client A failed to connect: %v", err)
+	}
+	if respA.StatusCode != 200 {
+		t.Fatalf("Client A got status %d", respA.StatusCode)
+	}
+	// Client A does NOT read body. It just holds the connection.
+	// Since the backend sends infinite data, the buffer in Proxy (and OS buffers) will fill up.
+	// Eventually pmw.Write should block.
+
+	fmt.Println("Waiting for buffers to fill...")
+	time.Sleep(2 * time.Second) // Give it time to fill buffers and block pmw.Write
+
+	// 2. Client B connects to the SAME stream
+	fmt.Println("Step 2: Client B connecting...")
+	clientB := &http.Client{Timeout: 1 * time.Second} // Short timeout for B? No, we want it to connect then disconnect.
+	// We use a context to cancel B
+	ctxB, cancelB := context.WithCancel(context.Background())
+	reqB, _ := http.NewRequestWithContext(ctxB, "GET", proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+	
+	// Start B in goroutine so we can cancel it
+	var wgB sync.WaitGroup
+	wgB.Add(1)
+	go func() {
+		defer wgB.Done()
+		respB, err := clientB.Do(reqB)
+		if err == nil {
+			respB.Body.Close()
+		}
+	}()
+
+	// Wait a bit for B to connect and be added to writers
+	time.Sleep(500 * time.Millisecond)
+
+	// 3. Client B disconnects
+	fmt.Println("Step 3: Client B disconnecting...")
+	cancelB()
+	wgB.Wait()
+
+	// Wait for HandleStream to trigger StopStream -> Remove
+	time.Sleep(500 * time.Millisecond)
+
+	// 4. Client C connects (should succeed if no deadlock)
+	fmt.Println("Step 4: Client C connecting...")
+	clientC := &http.Client{Timeout: 2 * time.Second}
+	
+	doneC := make(chan error)
+	go func() {
+		respC, err := makeRequest(clientC, "otherstream") // different ID to trigger FetchStream -> Lock
+		if err != nil {
+			doneC <- err
+			return
+		}
+		respC.Body.Close()
+		doneC <- nil
+	}()
+
+	select {
+	case err := <-doneC:
+		if err != nil {
+			t.Fatalf("Client C failed: %v", err)
+		}
+		fmt.Println("Client C connected successfully!")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Client C timed out! Deadlock detected.")
+	}
+
+	// Cleanup Client A
+	respA.Body.Close()
+}
+
+func mustParseInt(s string) int {
+	var i int
+	fmt.Sscanf(s, "%d", &i)
+	return i
+}

--- a/acexy/repro_test.go
+++ b/acexy/repro_test.go
@@ -304,6 +304,74 @@ func TestMultiClientStreamSurvival(t *testing.T) {
 	}
 }
 
+// TestSingleClientEvictionNoCrash reproduces the container crash reported in
+// https://github.com/Javinator9889/acexy/issues/44#issuecomment-4057160200
+//
+// Scenario: a single-client stream where the only client never reads. The
+// PMultiWriter write timeout evicts it, causing OnEvict → releaseStream →
+// player.Body.Close(). This makes the copier's io.Copy return, and its
+// cleanup goroutine also calls PMultiWriter.Close(). Before the fix,
+// Close() panicked on the already-closed channel, crashing the process.
+//
+// In Go tests a panic in any goroutine kills the entire test binary, so
+// this test reliably fails (crashes) without the idempotent-Close fix.
+func TestSingleClientEvictionNoCrash(t *testing.T) {
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+
+	backend := startMockBackend()
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendURL.Hostname(),
+		Port:              mustParseInt(backendURL.Port()),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      10 * time.Second,
+		BufferSize:        1024, // small buffer so flushes happen quickly
+		NoResponseTimeout: 2 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Single client connects but NEVER reads — OS buffers fill,
+	// PMultiWriter evicts after 5 s, OnEvict fires with clients 1→0,
+	// releaseStream closes everything, copier goroutine also cleans up.
+	t.Log("Connecting single slow client...")
+	client := &http.Client{Transport: &http.Transport{}}
+	resp, err := client.Get(proxyServer.URL + "/ace/getstream?id=crash-repro")
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+
+	// Wait for the eviction (5 s timeout) + margin for the full
+	// releaseStream → copier cleanup chain to complete.
+	t.Log("Waiting for eviction + cleanup...")
+	time.Sleep(8 * time.Second)
+
+	// Close the response body after the dust has settled.
+	resp.Body.Close()
+
+	// Give a moment for any deferred goroutine panics to surface.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify the proxy is still alive by hitting the status endpoint.
+	statusResp, err := http.Get(proxyServer.URL + "/ace/status")
+	if err != nil {
+		t.Fatalf("Proxy is dead after eviction: %v", err)
+	}
+	statusResp.Body.Close()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("Proxy status returned %d, expected 200", statusResp.StatusCode)
+	}
+	t.Log("Proxy survived single-client eviction without crashing")
+}
+
 func mustParseInt(s string) int {
 	var i int
 	fmt.Sscanf(s, "%d", &i)

--- a/acexy/repro_test.go
+++ b/acexy/repro_test.go
@@ -798,6 +798,103 @@ func TestThreeClientStress(t *testing.T) {
 	t.Log("PASS: All 5 phases completed — proxy survived 3-client stress test")
 }
 
+// TestStreamFailureReturnsError verifies that when StartStream fails (e.g.,
+// the stream was released between FetchStream and StartStream due to rapid
+// switching), the client receives a proper HTTP error instead of a 200 OK
+// with no data (which causes players to show "loading forever").
+//
+// Before the fix, WriteHeader(200) was called before StartStream. If
+// StartStream then failed, the headers were already sent and the client
+// saw a 200 response with Content-Type video/MP2T but no body data,
+// causing an infinite loading spinner.
+func TestStreamFailureReturnsError(t *testing.T) {
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+
+	// Use a slow backend so we have time to release the stream between
+	// FetchStream and StartStream
+	backend := startSlowMockBackend(1 * time.Second)
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendURL.Hostname(),
+		Port:              mustParseInt(backendURL.Port()),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      10 * time.Second,
+		BufferSize:        1024,
+		NoResponseTimeout: 3 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Connect a client and then immediately disconnect. Because the backend
+	// is slow (1s delay), the client will connect via FetchStream (which
+	// creates the stream entry), but by the time StartStream tries to fetch
+	// the playback URL and re-checks the map, we may have already released
+	// the stream from another path. The critical test: the client must NOT
+	// get a 200 OK with empty body.
+	//
+	// To reliably trigger this, connect two clients to the same stream —
+	// client 1 connects and starts waiting for the slow backend, client 2
+	// also fetches the same stream. When client 1 disconnects rapidly, the
+	// stream may be released. Client 2's StartStream must handle this.
+
+	// First, test the basic case: a single client that connects normally
+	// should get data, not an empty response.
+	t.Log("Testing normal connection returns data...")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(proxyServer.URL + "/ace/getstream?id=normal-stream")
+	if err != nil {
+		t.Fatalf("Normal connection failed: %v", err)
+	}
+
+	// Read some data
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	resp.Body.Close()
+
+	if n == 0 {
+		t.Fatal("Normal stream returned 0 bytes — client would see loading forever")
+	}
+	t.Logf("Normal stream returned %d bytes (OK)", n)
+
+	// Wait for cleanup
+	time.Sleep(1 * time.Second)
+
+	// Now test that a connection to a non-existent stream returns an error,
+	// not a 200 with no data. We simulate this by connecting to a stream
+	// that will fail during StartStream.
+	t.Log("Testing that failed streams return proper HTTP errors...")
+
+	// The proxy should respond with a proper error status when things fail,
+	// not a 200 OK with empty body
+	resp2, err := http.Get(proxyServer.URL + "/ace/getstream")
+	if err != nil {
+		t.Logf("Connection error (expected): %v", err)
+	} else {
+		if resp2.StatusCode == http.StatusOK {
+			// If we got 200, there MUST be data
+			buf2 := make([]byte, 1024)
+			n2, _ := resp2.Body.Read(buf2)
+			resp2.Body.Close()
+			if n2 == 0 {
+				t.Fatal("Got 200 OK but no data — this causes infinite loading in players")
+			}
+		} else {
+			resp2.Body.Close()
+			t.Logf("Got proper error status %d (OK)", resp2.StatusCode)
+		}
+	}
+
+	t.Log("PASS: Stream responses are correct (data on success, error on failure)")
+}
+
 func mustParseInt(s string) int {
 	var i int
 	fmt.Sscanf(s, "%d", &i)

--- a/acexy/repro_test.go
+++ b/acexy/repro_test.go
@@ -188,6 +188,122 @@ func TestDeadlockReproduction(t *testing.T) {
 	respA.Body.Close()
 }
 
+// TestMultiClientStreamSurvival verifies that when a slow client is evicted,
+// the stream continues working for healthy clients. This is the core regression
+// test for the bug where a single slow writer killed the entire stream.
+func TestMultiClientStreamSurvival(t *testing.T) {
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+
+	backend := startMockBackend()
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	// Use a small buffer so flushes happen quickly
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendURL.Hostname(),
+		Port:              mustParseInt(backendURL.Port()),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      10 * time.Second,
+		BufferSize:        1024,
+		NoResponseTimeout: 2 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	streamID := "survival-test"
+
+	// Client A: healthy reader that actively consumes data
+	t.Log("Client A connecting (healthy reader)...")
+	clientA := &http.Client{Transport: &http.Transport{}}
+	reqA, _ := http.NewRequest("GET", proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+	respA, err := clientA.Do(reqA)
+	if err != nil {
+		t.Fatalf("Client A failed to connect: %v", err)
+	}
+	defer respA.Body.Close()
+
+	// Start actively reading Client A's data in background
+	bytesReadA := make(chan int64, 1)
+	clientAErr := make(chan error, 1)
+	ctx, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	go func() {
+		buf := make([]byte, 4096)
+		var total int64
+		for {
+			select {
+			case <-ctx.Done():
+				bytesReadA <- total
+				return
+			default:
+			}
+			n, err := respA.Body.Read(buf)
+			total += int64(n)
+			if err != nil {
+				clientAErr <- err
+				bytesReadA <- total
+				return
+			}
+		}
+	}()
+
+	// Wait for Client A to start receiving data
+	time.Sleep(500 * time.Millisecond)
+
+	// Client B: slow reader that never reads (will be evicted by PMultiWriter timeout)
+	t.Log("Client B connecting (slow reader - will be evicted)...")
+	clientB := &http.Client{Transport: &http.Transport{}}
+	reqB, _ := http.NewRequest("GET", proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+	respB, err := clientB.Do(reqB)
+	if err != nil {
+		t.Fatalf("Client B failed to connect: %v", err)
+	}
+	// Client B does NOT read. Its OS buffers will fill, then PMultiWriter will evict it.
+
+	// Wait for PMultiWriter's write timeout (5s) to evict Client B, plus margin
+	t.Log("Waiting for Client B eviction...")
+	time.Sleep(8 * time.Second)
+
+	// Close Client B's body now (after eviction)
+	respB.Body.Close()
+
+	// Verify Client A is still receiving data AFTER eviction
+	t.Log("Verifying Client A is still alive after eviction...")
+
+	// Check that no read error occurred on Client A
+	select {
+	case err := <-clientAErr:
+		t.Fatalf("Client A got an error (stream was killed): %v", err)
+	default:
+		// No error - good
+	}
+
+	// Read a bit more data to confirm the stream is still flowing
+	time.Sleep(2 * time.Second)
+
+	select {
+	case err := <-clientAErr:
+		t.Fatalf("Client A got an error after waiting (stream died): %v", err)
+	default:
+		// Still no error - stream survived!
+	}
+
+	// Stop Client A and check total bytes
+	cancelA()
+	totalBytes := <-bytesReadA
+	t.Logf("Client A read %d bytes total - stream survived slow consumer eviction", totalBytes)
+
+	if totalBytes == 0 {
+		t.Fatal("Client A read 0 bytes - stream was not working")
+	}
+}
+
 func mustParseInt(s string) int {
 	var i int
 	fmt.Sscanf(s, "%d", &i)

--- a/acexy/repro_test.go
+++ b/acexy/repro_test.go
@@ -372,6 +372,432 @@ func TestSingleClientEvictionNoCrash(t *testing.T) {
 	t.Log("Proxy survived single-client eviction without crashing")
 }
 
+// TestRapidChannelSwitching reproduces the crash from rapid IPTV channel
+// scanning reported in https://github.com/Javinator9889/acexy/issues/44.
+//
+// The IPTV client connects to a channel, stays <1 second, disconnects, and
+// immediately connects to the next channel. This creates a race between
+// releaseStream (called from StopStream under mutex) and the copier
+// goroutine, both trying to close(ongoingStream.done). Before the sync.Once
+// fix, this was a select/default pattern that allowed concurrent callers
+// to both call close() — panicking with "close of closed channel".
+//
+// The test launches 20 streams sequentially with rapid connect/disconnect
+// to maximize the probability of hitting the race window. A panic in any
+// goroutine kills the entire test binary, so if this test crashes, the
+// race is present.
+func TestRapidChannelSwitching(t *testing.T) {
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+
+	backend := startMockBackend()
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendURL.Hostname(),
+		Port:              mustParseInt(backendURL.Port()),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      10 * time.Second,
+		BufferSize:        1024, // small buffer for fast flushes
+		NoResponseTimeout: 2 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Simulate rapid channel switching: connect, read briefly, disconnect, repeat
+	for i := 0; i < 20; i++ {
+		streamID := fmt.Sprintf("rapid-switch-%d", i)
+		t.Logf("Channel %d: switching to %s", i, streamID)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		req, _ := http.NewRequestWithContext(ctx, "GET",
+			proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+
+		client := &http.Client{Transport: &http.Transport{}}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Logf("Channel %d: connection error (expected during rapid switching): %v", i, err)
+			cancel()
+			continue
+		}
+
+		// Read a tiny bit of data (or nothing at all) then immediately disconnect
+		buf := make([]byte, 512)
+		resp.Body.Read(buf) // may or may not succeed — doesn't matter
+		cancel()            // trigger client disconnect
+		resp.Body.Close()
+
+		// Minimal delay — just enough for goroutine scheduling
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait for all goroutines spawned during the rapid switching to settle.
+	// The copier goroutines and eviction callbacks run asynchronously.
+	t.Log("Waiting for goroutine cleanup...")
+	time.Sleep(2 * time.Second)
+
+	// Verify the proxy is still alive
+	statusResp, err := http.Get(proxyServer.URL + "/ace/status")
+	if err != nil {
+		t.Fatalf("Proxy is dead after rapid channel switching: %v", err)
+	}
+	statusResp.Body.Close()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("Proxy status returned %d, expected 200", statusResp.StatusCode)
+	}
+	t.Log("Proxy survived rapid channel switching without crashing")
+}
+
+// startSlowMockBackend returns a mock AceStream backend where the
+// /ace/getstream API response is delayed by the given duration. This
+// simulates the real AceStream engine which can take several seconds to
+// set up a P2P stream before returning the playback URL.
+func startSlowMockBackend(apiDelay time.Duration) *httptest.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/ace/getstream", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(apiDelay)
+		host := r.Host
+		jsonResp := fmt.Sprintf(`{
+			"response": {
+				"playback_url": "http://%s/stream",
+				"stat_url": "http://%s/stat",
+				"command_url": "http://%s/command",
+				"infohash": "hash",
+				"playback_session_id": "session",
+				"is_live": 1,
+				"is_encrypted": 0,
+				"client_session_id": 123
+			},
+			"error": null
+		}`, host, host, host)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(jsonResp))
+	})
+
+	mux.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
+		chunk := make([]byte, 1024)
+		for i := range chunk {
+			chunk[i] = 'A'
+		}
+		for {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+	})
+
+	mux.HandleFunc("/command", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"response": "ok", "error": null}`))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// TestRapidSwitchingWithSlowBackend reproduces the proxy hang reported in
+// https://github.com/Javinator9889/acexy/issues/44 when rapidly switching
+// channels with a slow AceStream backend.
+//
+// Before the fix, FetchStream and StartStream held a.mutex during HTTP calls
+// to the backend (up to NoResponseTimeout). Rapid channel switching piled up
+// goroutines on the mutex, making the proxy completely unresponsive — even
+// /ace/status would time out.
+//
+// The fix releases the mutex before HTTP calls and re-acquires after.
+// This test verifies that /ace/status responds within 1 second while
+// multiple slow FetchStream calls are in flight.
+func TestRapidSwitchingWithSlowBackend(t *testing.T) {
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+
+	// Backend takes 2 seconds to respond to each /ace/getstream request
+	backend := startSlowMockBackend(2 * time.Second)
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendURL.Hostname(),
+		Port:              mustParseInt(backendURL.Port()),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      10 * time.Second,
+		BufferSize:        1024,
+		NoResponseTimeout: 5 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Launch 5 rapid channel switches — each will block for 2s on the backend
+	t.Log("Launching 5 concurrent stream requests (each takes 2s on backend)...")
+	for i := 0; i < 5; i++ {
+		go func(id int) {
+			streamID := fmt.Sprintf("slow-backend-%d", id)
+			ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+			defer cancel()
+			req, _ := http.NewRequestWithContext(ctx, "GET",
+				proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+			client := &http.Client{Transport: &http.Transport{}}
+			resp, err := client.Do(req)
+			if err == nil {
+				resp.Body.Close()
+			}
+		}(i)
+	}
+
+	// Give the requests a moment to reach FetchStream and block on the backend
+	time.Sleep(500 * time.Millisecond)
+
+	// The critical test: /ace/status must respond quickly even while
+	// 5 FetchStream calls are blocked waiting on the slow backend.
+	// Before the fix, this would time out because all operations were
+	// serialized through the mutex.
+	t.Log("Checking /ace/status while backend calls are in flight...")
+	statusClient := &http.Client{Timeout: 1 * time.Second}
+	statusResp, err := statusClient.Get(proxyServer.URL + "/ace/status")
+	if err != nil {
+		t.Fatalf("Status endpoint blocked while backend calls in flight: %v"+
+			"\nThis means the mutex is held during HTTP calls (pre-fix behavior)", err)
+	}
+	statusResp.Body.Close()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("Status returned %d, expected 200", statusResp.StatusCode)
+	}
+	t.Log("PASS: Status endpoint responded while slow backend calls were in flight")
+
+	// Wait for all backend calls to finish
+	time.Sleep(3 * time.Second)
+}
+
+// TestThreeClientStress exercises the proxy under a realistic multi-client
+// workload that mixes long-playing streams with rapid channel switching.
+//
+// The test runs five phases:
+//  1. Three clients each long-play a different channel
+//  2. One client rapid-switches while two long-play
+//  3. Two clients rapid-switch while one long-plays
+//  4. Two clients long-play the SAME channel while one rapid-switches
+//  5. All three long-play different channels again (stability check)
+//
+// Throughout all phases, the proxy must stay responsive (health check via
+// /ace/status responds within 1 second) and long-playing clients must
+// continue to receive data without interruption.
+func TestThreeClientStress(t *testing.T) {
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+
+	backend := startMockBackend()
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	a := &acexy.Acexy{
+		Scheme:            "http",
+		Host:              backendURL.Hostname(),
+		Port:              mustParseInt(backendURL.Port()),
+		Endpoint:          acexy.MPEG_TS_ENDPOINT,
+		EmptyTimeout:      30 * time.Second,
+		BufferSize:        1024,
+		NoResponseTimeout: 2 * time.Second,
+	}
+	a.Init()
+
+	proxy := &Proxy{Acexy: a}
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// longPlay streams data from a channel, recording bytes received.
+	// Returns a cancel func and a channel that will receive total bytes
+	// when the stream ends.
+	longPlay := func(name, streamID string) (context.CancelFunc, <-chan int64, <-chan error) {
+		ctx, cancel := context.WithCancel(context.Background())
+		bytesRead := make(chan int64, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			req, _ := http.NewRequestWithContext(ctx, "GET",
+				proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+			client := &http.Client{Transport: &http.Transport{}}
+			resp, err := client.Do(req)
+			if err != nil {
+				errCh <- err
+				bytesRead <- 0
+				return
+			}
+			defer resp.Body.Close()
+			buf := make([]byte, 4096)
+			var total int64
+			for {
+				n, err := resp.Body.Read(buf)
+				total += int64(n)
+				if err != nil {
+					bytesRead <- total
+					return
+				}
+			}
+		}()
+		return cancel, bytesRead, errCh
+	}
+
+	// rapidSwitch connects and disconnects from N different channels quickly.
+	rapidSwitch := func(name string, count int, interval time.Duration) {
+		for i := 0; i < count; i++ {
+			streamID := fmt.Sprintf("%s-switch-%d", name, i)
+			ctx, cancel := context.WithCancel(context.Background())
+			req, _ := http.NewRequestWithContext(ctx, "GET",
+				proxyServer.URL+"/ace/getstream?id="+streamID, nil)
+			client := &http.Client{Transport: &http.Transport{}}
+			resp, err := client.Do(req)
+			if err == nil {
+				buf := make([]byte, 512)
+				resp.Body.Read(buf)
+				resp.Body.Close()
+			}
+			cancel()
+			time.Sleep(interval)
+		}
+	}
+
+	checkHealth := func(phase string) {
+		t.Helper()
+		statusClient := &http.Client{Timeout: 1 * time.Second}
+		resp, err := statusClient.Get(proxyServer.URL + "/ace/status")
+		if err != nil {
+			t.Fatalf("[%s] Proxy unresponsive: %v", phase, err)
+		}
+		resp.Body.Close()
+	}
+
+	// ── Phase 1: Three clients long-play different channels ──
+	t.Log("Phase 1: Three clients long-playing different channels")
+	cancelA, bytesA, _ := longPlay("A", "long-A")
+	cancelB, bytesB, _ := longPlay("B", "long-B")
+	cancelC, bytesC, _ := longPlay("C", "long-C")
+	time.Sleep(500 * time.Millisecond)
+	checkHealth("Phase 1")
+	cancelA()
+	cancelB()
+	cancelC()
+	bA := <-bytesA
+	bB := <-bytesB
+	bC := <-bytesC
+	t.Logf("Phase 1: A=%d B=%d C=%d bytes", bA, bB, bC)
+	if bA == 0 || bB == 0 || bC == 0 {
+		t.Fatal("Phase 1: at least one client received no data")
+	}
+
+	time.Sleep(200 * time.Millisecond) // let goroutines settle
+
+	// ── Phase 2: A+C long-play, B rapid-switches ──
+	t.Log("Phase 2: A+C long-play, B rapid-switches")
+	cancelA, bytesA, errA := longPlay("A", "long-A-p2")
+	cancelC, bytesC, errC := longPlay("C", "long-C-p2")
+	time.Sleep(300 * time.Millisecond)
+	rapidSwitch("B", 8, 50*time.Millisecond)
+	checkHealth("Phase 2 after switching")
+	// Verify A and C are still alive (no error)
+	select {
+	case err := <-errA:
+		t.Fatalf("Phase 2: Client A died during switching: %v", err)
+	default:
+	}
+	select {
+	case err := <-errC:
+		t.Fatalf("Phase 2: Client C died during switching: %v", err)
+	default:
+	}
+	cancelA()
+	cancelC()
+	bA = <-bytesA
+	bC = <-bytesC
+	t.Logf("Phase 2: A=%d C=%d bytes", bA, bC)
+	if bA == 0 || bC == 0 {
+		t.Fatal("Phase 2: long-playing client received no data")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	// ── Phase 3: A+B rapid-switch, C long-plays ──
+	t.Log("Phase 3: A+B rapid-switch concurrently, C long-plays")
+	cancelC, bytesC, errC = longPlay("C", "long-C-p3")
+	time.Sleep(300 * time.Millisecond)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); rapidSwitch("A", 6, 30*time.Millisecond) }()
+	go func() { defer wg.Done(); rapidSwitch("B", 6, 30*time.Millisecond) }()
+	wg.Wait()
+	checkHealth("Phase 3 after dual switching")
+	select {
+	case err := <-errC:
+		t.Fatalf("Phase 3: Client C died during dual switching: %v", err)
+	default:
+	}
+	cancelC()
+	bC = <-bytesC
+	t.Logf("Phase 3: C=%d bytes", bC)
+	if bC == 0 {
+		t.Fatal("Phase 3: long-playing client received no data")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	// ── Phase 4: A+B long-play SAME channel, C rapid-switches ──
+	t.Log("Phase 4: A+B same channel, C rapid-switches")
+	cancelA, bytesA, errA = longPlay("A", "shared-channel")
+	cancelB, bytesB, errB := longPlay("B", "shared-channel")
+	time.Sleep(300 * time.Millisecond)
+	rapidSwitch("C", 8, 50*time.Millisecond)
+	checkHealth("Phase 4 after switching")
+	select {
+	case err := <-errA:
+		t.Fatalf("Phase 4: Client A died during switching: %v", err)
+	default:
+	}
+	select {
+	case err := <-errB:
+		t.Fatalf("Phase 4: Client B died during switching: %v", err)
+	default:
+	}
+	cancelA()
+	cancelB()
+	bA = <-bytesA
+	bB = <-bytesB
+	t.Logf("Phase 4: A=%d B=%d bytes (same channel)", bA, bB)
+	if bA == 0 || bB == 0 {
+		t.Fatal("Phase 4: shared-channel client received no data")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	// ── Phase 5: All three long-play again (stability) ──
+	t.Log("Phase 5: All three long-play (final stability check)")
+	cancelA, bytesA, _ = longPlay("A", "final-A")
+	cancelB, bytesB, _ = longPlay("B", "final-B")
+	cancelC, bytesC, _ = longPlay("C", "final-C")
+	time.Sleep(500 * time.Millisecond)
+	checkHealth("Phase 5")
+	cancelA()
+	cancelB()
+	cancelC()
+	bA = <-bytesA
+	bB = <-bytesB
+	bC = <-bytesC
+	t.Logf("Phase 5: A=%d B=%d C=%d bytes", bA, bB, bC)
+	if bA == 0 || bB == 0 || bC == 0 {
+		t.Fatal("Phase 5: at least one client received no data after stress test")
+	}
+
+	t.Log("PASS: All 5 phases completed — proxy survived 3-client stress test")
+}
+
 func mustParseInt(s string) int {
 	var i int
 	fmt.Sscanf(s, "%d", &i)

--- a/bug-44.md
+++ b/bug-44.md
@@ -1,0 +1,44 @@
+# Bug #44: Proxy hangs when switching channels quickly
+
+## Analysis
+The issue was identified as a deadlock in the `PMultiWriter` implementation used by the proxy to broadcast stream data to multiple clients.
+
+When a client stops reading data (but stays connected), the `PMultiWriter.Write` method blocks waiting for that client's write to complete (or fail).
+The original implementation of `PMultiWriter.Write` held a `RLock` on the `PMultiWriter` instance while waiting for all writes to complete.
+
+When another client connects or disconnects (switching channels), the proxy attempts to Add or Remove a writer from the `PMultiWriter`.
+Both `Add` and `Remove` require a `Lock` (write lock).
+Because `Write` was holding the `RLock` indefinitely (due to the blocking client), `Add`/`Remove` would block indefinitely.
+
+Since `StartStream` and `StopStream` (which call `Add`/`Remove`) are called with the global `Acexy` mutex held (or `ongoingStream` mutex), this blocked the entire proxy, preventing any new connections or status checks.
+
+## Reproduction
+A synthetic test case was created in `acexy/repro_test.go` (`TestDeadlockReproduction`).
+The test simulates:
+1. Client A connecting and blocking reads (filling the buffer).
+2. Client B connecting to the same stream.
+3. Client B disconnecting (triggering `StopStream` -> `Remove`).
+4. Client C connecting to a different stream (triggering `StartStream` -> `Lock`).
+
+Before the fix, Client C would time out because `StopStream` for Client B was blocked, holding the locks.
+
+## Fix
+The `PMultiWriter.Write` method in `acexy/lib/pmw/pmw.go` was modified to:
+1. Acquire `RLock`.
+2. Create a local copy of the list of writers.
+3. Release `RLock` immediately.
+4. Perform the writes using the local copy.
+
+This ensures that `Add` and `Remove` operations can proceed even if a `Write` operation is blocked waiting for a slow client.
+
+## Verification
+The regression test `acexy/repro_test.go` passes with the fix applied.
+```
+=== RUN   TestDeadlockReproduction
+...
+Client C connected successfully!
+...
+--- PASS: TestDeadlockReproduction (3.01s)
+PASS
+ok      javinator9889/acexy     3.010s
+```

--- a/bug-44.md
+++ b/bug-44.md
@@ -31,7 +31,12 @@ The `PMultiWriter.Write` method in `acexy/lib/pmw/pmw.go` was modified to:
 3. Release `RLock` immediately.
 4. Perform the writes using the local copy.
 
-This ensures that `Add` and `Remove` operations can proceed even if a `Write` operation is blocked waiting for a slow client.
+### Slow Consumer Eviction
+Additionally, `PMultiWriter` now supports automatic eviction of slow consumers:
+- Each `Write` operation is protected by a `writeTimeout` (defaulting to 5 seconds).
+- If a writer stalls and exceeds this timeout, it is automatically removed from the `PMultiWriter` broadcast list.
+- This prevents a single bad client from blocking the entire data stream for other healthy clients.
+- Even if a write is stalled, the main proxy remains responsive because the state is decoupled from the actual IO operations.
 
 ## Verification
 The regression test `acexy/repro_test.go` passes with the fix applied.

--- a/bug-44.md
+++ b/bug-44.md
@@ -14,13 +14,15 @@ Since `StartStream` and `StopStream` (which call `Add`/`Remove`) are called with
 
 ## Reproduction
 A synthetic test case was created in `acexy/repro_test.go` (`TestDeadlockReproduction`).
-The test simulates:
+The test is self-contained and uses a mock AceStream backend (`startMockBackend`) created with `httptest.NewServer`. It simulates:
 1. Client A connecting and blocking reads (filling the buffer).
 2. Client B connecting to the same stream.
 3. Client B disconnecting (triggering `StopStream` -> `Remove`).
 4. Client C connecting to a different stream (triggering `StartStream` -> `Lock`).
 
-Before the fix, Client C would time out because `StopStream` for Client B was blocked, holding the locks.
+### Verification of Test and Fix
+- **Without the fix**: The test consistently fails with a timeout because Step 4 (Client C connecting) is blocked by the deadlock.
+- **With the fix**: The test passes consistently, even under parallel stress testing.
 
 ## Fix
 The `PMultiWriter.Write` method in `acexy/lib/pmw/pmw.go` was modified to:


### PR DESCRIPTION
The proxy was using the default values when serving requests, which is infinite. This means if any client hangs for whatever reason while reading/writing - although this problem mostly happens during a write operation - it blocks every other process that is waiting to have a free channel.

With the new adjustments, the server times out a request whenever it takes longer than expected. These values were adjusted to 5s for readings, and 10s for writings.

Closes #44 